### PR TITLE
Refactor prereq-setup into quickstart

### DIFF
--- a/docs/android-native/quickstart.md
+++ b/docs/android-native/quickstart.md
@@ -18,7 +18,7 @@ The Solana Mobile SDK's provides a [Mobile Wallet Adapter](https://github.com/so
 
 - Download [Android Studio](https://developer.android.com/studio) or your Android development IDE of choice.
 
-- Follow the [prerequisite setup](../getting-started/prerequisite_setup#install-a-wallet-app) guide to set up your [Android Device/Emulator](../getting-started/prerequisite_setup#android-deviceemulator) and install a MWA-compatible wallet, like [fakewallet](../getting-started/prerequisite_setup#install-a-wallet-app).
+- Follow the [prerequisite setup](../getting-started/quickstart#prerequisite-setup) guide to set up your [Android Device/Emulator](../getting-started/quickstart#android-deviceemulator) and install a MWA-compatible wallet, like [fakewallet](../getting-started/quickstart#install-a-wallet-app).
 
 
 ### Setting up an Android Project 

--- a/docs/getting-started/intro.md
+++ b/docs/getting-started/intro.md
@@ -11,7 +11,7 @@ The **Solana Mobile Stack (SMS)** is an open source collection of libraries that
 The SDK is primarily developed and maintained by the [Solana Mobile](https://github.com/solana-mobile) team, but welcomes contributions from the community!
 
 :::note
-You don't need a Saga device or physical device to build on Solana Mobile. See [**prerequisite setup**](prerequisite_setup) to set up your development environment and start building!
+You don't need a Saga device or physical device to build on Solana Mobile. See [**prerequisite setup**](quickstart#prerequisite-setup) to set up your development environment and start building!
 :::
 
 ## Quickstart 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -3,12 +3,45 @@ import TabItem from '@theme/TabItem';
 import Card from "../../src/components/Card"
 import CardLayout from "../../src/layouts/CardLayout"
 
-# Prerequisite Setup
+# Quickstart
 
 This guide will demonstrate how to quickly install necessary tools and set up your development environment, getting you ready to start
 building a mobile app on Solana. 
 
-If you are familiar with mobile development, you can skip to [choosing a development framework](#choose-a-development-framework).
+## Choose a development framework
+
+Currently, the Solana Mobile SDK can be installed as a dependency for Android apps built in React Native and Android Native. In the future, there will be support for additional frameworks like Flutter/Dart. 
+
+<CardLayout>
+    <Card
+        to="/react-native/quickstart"
+        header={{
+            label: "React Native Quickstart",
+            translateId: "developer-programs",
+        }}
+        body={{
+            label: "Quickly set up a React Native project and start building on Solana Mobile with our Javascript SDKs.",
+            translateId: "learn-programs",
+        }}
+        iconPath="img/react-native-96.svg"
+    />
+    <Card
+        to="/android-native/quickstart"
+        header={{
+            label: "Android Quickstart",
+            translateId: "development-setup",
+        }}
+        body={{
+            label: "Quickly set up an Android project and start building on Solana Mobile with our Android SDK.",
+            translateId: "development-setup-body",
+        }}
+        iconPath="img/android_icon.svg"
+    />
+</CardLayout>
+
+## Prerequisite Setup
+
+Regardless of framework choice, ensure you follow this prerequisite setup guide to fully test integration of your app.
 
 ### Android Device/Emulator
 
@@ -54,38 +87,4 @@ git clone https://github.com/solana-mobile/mobile-wallet-adapter.git
 #### Production
 
 Fakewallet was created for implementation reference and quick testing purposes. For production testing, test your dApp with popular MWA-compatible wallet apps like [Phantom](https://play.google.com/store/apps/details?id=app.phantom) and [Solflare](https://play.google.com/store/apps/details?id=com.solflare.mobile).
-
-### Choose a development framework
-
-Currently, the Solana Mobile SDK can be installed as a dependency for apps built in React Native and Android Native. In the future, there will be support for additional frameworks like React Native Expo, Flutter/Dart.
-
-<CardLayout>
-    <Card
-        to="/react-native/quickstart"
-        header={{
-            label: "React Native Quickstart",
-            translateId: "developer-programs",
-        }}
-        body={{
-            label: "Quickly set up a React Native project and start building on Solana Mobile with our Javascript SDKs.",
-            translateId: "learn-programs",
-        }}
-        iconPath="img/react-native-96.svg"
-    />
-    <Card
-        to="/android-native/quickstart"
-        header={{
-            label: "Android Quickstart",
-            translateId: "development-setup",
-        }}
-        body={{
-            label: "Quickly set up an Android project and start building on Solana Mobile with our Android SDK.",
-            translateId: "development-setup-body",
-        }}
-        iconPath="img/android_icon.svg"
-    />
-</CardLayout>
-
-
-
 

--- a/docs/react-native/hello_world_tutorial.md
+++ b/docs/react-native/hello_world_tutorial.md
@@ -17,7 +17,7 @@ By the end of this tutorial, you'll have an understanding of how to use the Sola
 - How to use the memo program to write your message to the network and see your message on the blockchain!
 
 ## Prerequisites
-Read the [**prerequisite setup**](../getting-started/prerequisite_setup) guide before starting the tutorial. This tutorial will be using the [fakewallet](../getting-started/prerequisite_setup#install-test-wallet-app) app to test your app's integration with Mobile Wallet Adapter.
+Read the [**prerequisite setup**](../getting-started/quickstart) guide before starting the tutorial. This tutorial will be using the [fakewallet](../getting-started/quickstart#install-test-wallet-app) app to test your app's integration with Mobile Wallet Adapter.
 
 ### Clone the tutorial repo
 

--- a/docs/react-native/quickstart.md
+++ b/docs/react-native/quickstart.md
@@ -20,7 +20,7 @@ You can continue using well supported and useful Solana web libraries like [`@so
 
 ### Prerequisites
 
-Follow the [prerequisite setup](../getting-started/prerequisite_setup#install-a-wallet-app) guide to set up your [Android Device/Emulator](../getting-started/prerequisite_setup#android-deviceemulator) and install a MWA-compatible wallet, like [fakewallet](../getting-started/prerequisite_setup#install-a-wallet-app).
+Follow the [prerequisite setup](../getting-started/quickstart#prerequisite-setup) guide to set up your [Android Device/Emulator](../getting-started/quickstart#android-deviceemulator) and install a MWA-compatible wallet, like [fakewallet](../getting-started/quickstart#install-a-wallet-app).
 
 ### Clone Solana Mobile dApp Scaffold
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -35,8 +35,8 @@ const sidebars = {
         },
         {
           type: 'doc',
-          id: 'getting-started/prerequisite_setup',
-          label: 'Prerequisite Setup'
+          id: 'getting-started/quickstart',
+          label: 'Quickstart'
         },
       ],
     },

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -34,7 +34,7 @@ function HomeCallToAction() {
     <>
       <ActionButton
         type="primary"
-        href={useBaseUrl('getting-started/prerequisite_setup')}
+        href={useBaseUrl('getting-started/quickstart')}
         target="_self">
         Get started
       </ActionButton>
@@ -42,7 +42,7 @@ function HomeCallToAction() {
         type="secondary"
         href={useBaseUrl('getting-started/intro')}
         target="_self">
-        Learn the basics
+        Browse the docs
       </ActionButton>
     </>
   );


### PR DESCRIPTION
Refactoring `getting-started/prerequisites-setup` into `getting-started/quickstart`. Now the `prerequisites-setup` will be a subsection within `quickstart`.

Having a `quickstart` as part of the getting started category is helpful for users that want the quickest path to development.