### PR TITLE
Update using_mobile_wallet_adapter.md

### DIFF
--- a/docs/react-native/using_mobile_wallet_adapter.md
+++ b/docs/react-native/using_mobile_wallet_adapter.md
@@ -21,7 +21,7 @@ These libraries provide a convenient API to connect, issue signing requests to a
 <TabItem value="yarn" label="yarn">
 
 ```bash
-yarn install @solana-mobile/mobile-wallet-adapter-protocol-web3js \
+yarn add @solana-mobile/mobile-wallet-adapter-protocol-web3js \
              @solana-mobile/mobile-wallet-adapter-protocol
 ```
 


### PR DESCRIPTION
error `install` has been replaced with `add` to add new dependencies. Run "yarn add @solana-mobile/mobile-wallet-adapter-protocol-web3js @solana-mobile/mobile-wallet-adapter-protocol" instead.